### PR TITLE
Added support for up-to-date currency rates.

### DIFF
--- a/lib/CurrencyHelper.ts
+++ b/lib/CurrencyHelper.ts
@@ -37,6 +37,9 @@ module CurrencyHelper {
     }
 
     export function getData(): Data {
+        if (typeof data === "undefined"){
+            return getOldData();
+        }
         return data;
     }
 

--- a/lib/CurrencyHelper.ts
+++ b/lib/CurrencyHelper.ts
@@ -15,11 +15,43 @@ module CurrencyHelper {
     let data: Data;
 
     export function initialize(): void {
-        data = JSON.parse(raw);
+        //data = JSON.parse(raw);
+        fetchRates().then((res) => {
+            // if API not accessible, take old data
+            if (res === null) {
+                data = JSON.parse(raw);
+                return;
+            }
+            let rates = {};
+            for (let key in res)
+                rates[key] = [res[key], 2];
+            // takes only pre-defined symbols. API may be expandable for many more currencies
+            data = {
+                'date': new Date().toISOString().slice(0, 10),
+                'rates': rates,
+                'symbols': JSON.parse(raw).symbols
+            };
+            console.debug("[BuffUtility] Fetched new currency exchange rates.");
+        });
+
     }
 
     export function getData(): Data {
         return data;
+    }
+
+    /**
+     * Uses the exchangerate.host free API to get current exchance rates with base CNY
+     * @returns Exchange rates in format: {currency:value} 
+     */
+    async function fetchRates(): Promise<any> {
+        return fetch('https://api.exchangerate.host/latest?base=CNY')
+                .then(res => res.json())
+                .then(res => {
+                    if (!res?.success)
+                        return null;
+                    return res?.rates;
+                });
     }
 
 }

--- a/lib/CurrencyHelper.ts
+++ b/lib/CurrencyHelper.ts
@@ -40,6 +40,10 @@ module CurrencyHelper {
         return data;
     }
 
+    export function getOldData(): Data {
+        return JSON.parse(raw);
+    }
+
     /**
      * Uses the exchangerate.host free API to get current exchance rates with base CNY
      * @returns Exchange rates in format: {currency:value} 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
     "version": "1.0.0",
     "private": true,
     "devDependencies": {
-        "@types/jquery": "3.5.13"
+        "@types/jquery": "3.5.13",
+        "@types/node": "^18.0.5"
     },
     "dependencies": {
+        "csstype": "^3.1.0",
         "typescript": "4.5.5"
     }
 }

--- a/sources/Adjust_Settings.ts
+++ b/sources/Adjust_Settings.ts
@@ -328,7 +328,19 @@ module Adjust_Settings {
         table.setAttribute('width', '100%');
 
         // currency selection
-        const { rates, symbols } = CurrencyHelper.getData();
+        const currencyData: CurrencyHelper.Data | undefined = CurrencyHelper.getData();
+        let rates: CurrencyHelper.Data["rates"] = null;
+        let symbols: CurrencyHelper.Data["symbols"] = null;
+        if (typeof currencyData === "undefined") {
+            const data: CurrencyHelper.Data = CurrencyHelper.getOldData();
+            rates = data.rates;
+            symbols = data.symbols;
+        } else {
+            rates = currencyData.rates;
+            symbols = currencyData.symbols;
+        }
+       
+        
 
         let remapped = Object.keys(rates).map(x => {
             return {

--- a/sources/Start.ts
+++ b/sources/Start.ts
@@ -56,7 +56,25 @@ function adjustFloatBar(): void {
     }
 }
 
+function adjustBalance(): void {
+    let balanceDiv = document.getElementsByClassName("store-account")[0].children[0];
+    let balYuan: number = +balanceDiv.innerHTML.split("¥ ")[1].split("<")[0];
+
+    let balNew = Util.buildHTML('span', {
+        content: [
+            Util.buildHTML('br', {}),
+            Util.buildHTML('span', {
+                class: 'c_Gray f_12px',
+                content: [ `(${Util.convertCNY(balYuan)})` ]
+            })
+        ]
+    });
+
+    balanceDiv.innerHTML += balNew;
+}
+
 adjustFloatBar();
+adjustBalance();
 
 if (storedSettings[Settings.USE_SCHEME]) {
     InjectionServiceLib.injectCSS(`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "module": "None",
+        "moduleResolution": "node",
         "target": "es5",
         "sourceMap": false,
         "inlineSourceMap": false,


### PR DESCRIPTION
As the Buff-Website offers currency conversion itself, the outdates exchanges rates of the extension felt really misleading. In this example of an AWP | Desert Hydra the difference is more than 40€.
With the old rates:
![Old extension](https://user-images.githubusercontent.com/21990230/179398257-b2ca0fb7-f26c-4214-aa53-79951735e991.png)
Without the extension:
![Without extension](https://user-images.githubusercontent.com/21990230/179398262-bc101fed-db7a-4ea0-b421-aa710bc9375e.png)
With my changes:
![With my changes](https://user-images.githubusercontent.com/21990230/179398358-39e5cf6c-b096-4b46-bd06-bb7dedaa2452.png)

This addition supports the automatic fetching of current currency exchange rates during initialization.
The free [exchangerate.host API](https://exchangerate.host/#/) provides up-to-date rates for this purpose.
