### PR TITLE
Fixed color scheme for favorites

### DIFF
--- a/sources/Start.ts
+++ b/sources/Start.ts
@@ -159,6 +159,15 @@ if (storedSettings[Settings.USE_SCHEME]) {
 .dark-theme .detail-tab-cont .market-card {
     background: ${storedSettings[Settings.COLOR_SCHEME][0]};
 }
+
+/* favorites */
+.dark-theme .l_Layout .cont_main .user-record {
+    background: ${storedSettings[Settings.COLOR_SCHEME][0]};
+}
+.dark-theme .l_Layout .cont_main .user-record a,
+.dark-theme .l_Layout .cont_main .user-record .delete-bookmark {
+    color: ${storedSettings[Settings.COLOR_SCHEME][2]} !important;
+}
 `);
 
     let body = document.querySelector('body');


### PR DESCRIPTION
Adjusting the BuffUtility color scheme (dark mode) did not change the colors on the "Favorites" site.

I added the injection for the background, a-tags and the remove link. Works for both tabs in the favorites.