### PR TITLE
Added bargaining feature in the Favorites tab

### DIFF
--- a/sources/Adjust_Favourites.ts
+++ b/sources/Adjust_Favourites.ts
@@ -83,6 +83,24 @@ module AdjustFavourites {
             aShare.setAttribute('target', '_blank');
 
             nameContainer.parentElement.appendChild(aShare);
+
+            //TODO: color coding on available balance
+            let parentBargain = row.lastElementChild;
+            let aBargain = <HTMLElement>parentBargain.querySelector('a').cloneNode(true);
+            // items below 100 yuan cannot be bargained
+            if (+aBargain.getAttribute('data-price') >= 100) {
+                parentBargain.setAttribute('style', 'line-height: 200%;');
+                aBargain.setAttribute('class', 'c_Blue2 bargain i_Btn i_Btn_mid');
+                aBargain.setAttribute('style', 'margin-left: 10px; border: 2px solid #4773C8; background: none; border-radius: 10px;');
+                aBargain.setAttribute('data-lowest-bargain-price', `${((+aBargain.getAttribute('data-price'))*0.8).toFixed(1)}`);
+                aBargain.removeAttribute('data-goods-sell-min-price');
+                aBargain.removeAttribute('data-cooldown');
+                aBargain.innerText = 'Bargain';
+                parentBargain.querySelector('span').setAttribute('style', 'margin-left: 50px;');
+
+                parentBargain.querySelector('a').after(aBargain);
+            }
+
         }
     }
 


### PR DESCRIPTION
Per default Buff allows bargaining only in the item listings. This feature gives the option to bargain on favorited items directly - without having to search the item in all market listings first.

The correct bargaining minimum (80% of listing price), the minimum listing price (100 yuan) as well as all modals have been tested and work as intended.

Previously:
![Screenshot_236](https://user-images.githubusercontent.com/21990230/189260871-989e0fcb-01e0-4935-ae1f-0a5c2532c6a2.png)

Now:
![Screenshot_237](https://user-images.githubusercontent.com/21990230/189260970-a5f32984-7969-4469-96e1-fe34e2de4301.png)

The design is intentionally not the same as in the market listings to avoid confusion with the "watched"-text and rather based on the "buy"-button. Feel free to change this at your will though.
