### PR TITLE
Added item price trend in item page header

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Buff Utility (Dev)",
-    "version": "2.1.5",
+    "version": "2.1.6",
     "description": "Adds cosmetic functionality to buff.163.com",
     "manifest_version": 3,
     "content_scripts": [

--- a/sources/Adjust_Listings.ts
+++ b/sources/Adjust_Listings.ts
@@ -138,6 +138,64 @@ module Adjust_Listings {
 
             adjustBuyOrderListings(<InjectionService.TransferData<BuffTypes.BuyOrder.Data>>transferData);
         }
+
+        if (!document.querySelector('span.buffutility-pricerange')) {
+            console.debug('[BuffUtility] Adjust_Listings (header)');
+            adjustHeaderListings();
+        }
+    }
+
+    async function adjustHeaderListings() {
+        let goods_id = +document.querySelector("div.detail-cont div.add-bookmark").getAttribute('data-target-id');
+        //discard dates from prices as not used
+        let history = (await fetchPriceHistory(goods_id, 30)).map((arr) => arr[1]);
+
+        let header = <HTMLElement>document.querySelector("body > div.market-list > div > div.detail-header.black");
+        let priceMin = history[0], priceMax = history[0];
+
+        for (let i=1;i<history.length;i++) {
+            if (history[i] < priceMin) {
+                priceMin = history[i];
+            }
+            if (history[i] > priceMax) {
+                priceMax = history[i];
+            }
+        }
+
+        let priceParent = <HTMLElement>header.querySelector("div.detail-summ");
+
+        let priceSpan = document.createElement('span');
+        let priceLabel = document.createElement('label');
+        let priceStrong = document.createElement('strong');
+
+        priceParent.setAttribute('style', 'line-height: 200%;');
+        priceSpan.setAttribute('class', 'buffutility-pricerange');
+        priceLabel.innerText = 'Buff Price Trend (7D) |';
+
+        priceStrong.innerHTML= `<strong class='f_Strong'>${Util.convertCNY(priceMin)}<small class="hide-usd">(MIN)</small></strong> — <strong class='f_Strong'>${Util.convertCNY(priceMax)}<small class="hide-usd">(MAX)</small></strong>`;
+
+        priceSpan.appendChild(priceLabel);
+        priceSpan.appendChild(priceStrong);
+        //prevent the double adding of the element caused by the async nature of the function
+        if (!document.querySelector('span.buffutility-pricerange')) {
+            priceParent.appendChild(document.createElement('br'));
+            priceParent.appendChild(priceSpan);
+        }
+    }
+
+    /**
+     * Fetch price history for a given item in the last X days
+     * @param goodsId
+     * @param days
+     * @returns Array of [timestamp, price in rmb] pairs
+     */
+    function fetchPriceHistory(goodsId: number, days: 7 | 30): Promise<[[number, number]]> {
+        return new Promise((resolve, _) => {
+            fetch(`https://buff.163.com/api/market/goods/price_history/buff?game=csgo&goods_id=${goodsId}&days=${days}`)
+            .then(r => r.json().then(_response => {
+                resolve(_response.data.price_history);
+            }));
+        });
     }
 
     function adjustSellOrderListings(transferData: InjectionService.TransferData<BuffTypes.SellOrder.Data>): void {

--- a/sources/Adjust_Listings.ts
+++ b/sources/Adjust_Listings.ts
@@ -145,10 +145,15 @@ module Adjust_Listings {
         }
     }
 
+    /**
+     * Adds a price range to the item overview ("header"). Supports 7 or 30 days ranges (default: 7).
+     */
     async function adjustHeaderListings() {
-        let goods_id = +document.querySelector("div.detail-cont div.add-bookmark").getAttribute('data-target-id');
+        //default price trend ranges: 7 oder 30 days (with observer benefit 180 days also possible)
+        const days: 7|30 = 7;
+        const goods_id = +document.querySelector("div.detail-cont div.add-bookmark").getAttribute('data-target-id');
         //discard dates from prices as not used
-        let history = (await fetchPriceHistory(goods_id, 30)).map((arr) => arr[1]);
+        let history = (await fetchPriceHistory(goods_id, days)).map((arr) => arr[1]);
 
         let header = <HTMLElement>document.querySelector("body > div.market-list > div > div.detail-header.black");
         let priceMin = history[0], priceMax = history[0];
@@ -186,7 +191,7 @@ module Adjust_Listings {
     /**
      * Fetch price history for a given item in the last X days
      * @param goodsId
-     * @param days
+     * @param days 7 or 30
      * @returns Array of [timestamp, price in rmb] pairs
      */
     function fetchPriceHistory(goodsId: number, days: 7 | 30): Promise<[[number, number]]> {

--- a/sources/Adjust_Listings.ts
+++ b/sources/Adjust_Listings.ts
@@ -139,7 +139,7 @@ module Adjust_Listings {
             adjustBuyOrderListings(<InjectionService.TransferData<BuffTypes.BuyOrder.Data>>transferData);
         }
 
-        if (!document.querySelector('span.buffutility-pricerange')) {
+        if (!document.querySelector('span.buffutility-pricerange') && storedSettings[Settings.EXPERIMENTAL_FETCH_ITEM_PRICE_HISTORY] > 0) {
             console.debug('[BuffUtility] Adjust_Listings (header)');
             adjustHeaderListings();
         }
@@ -150,7 +150,8 @@ module Adjust_Listings {
      */
     async function adjustHeaderListings() {
         //default price trend ranges: 7 oder 30 days (with observer benefit 180 days also possible)
-        const days: 7|30 = 7;
+        const settingsMap = {1: 7, 2: 30};
+        const days: 7|30 = settingsMap[storedSettings[Settings.EXPERIMENTAL_FETCH_ITEM_PRICE_HISTORY]];
         const goods_id = +document.querySelector("div.detail-cont div.add-bookmark").getAttribute('data-target-id');
         //discard dates from prices as not used
         let history = (await fetchPriceHistory(goods_id, days)).map((arr) => arr[1]);
@@ -175,7 +176,7 @@ module Adjust_Listings {
 
         priceParent.setAttribute('style', 'line-height: 200%;');
         priceSpan.setAttribute('class', 'buffutility-pricerange');
-        priceLabel.innerText = 'Buff Price Trend (7D) |';
+        priceLabel.innerText = `Buff Price Trend (${days}D) |`;
 
         priceStrong.innerHTML= `<strong class='f_Strong'>${Util.convertCNY(priceMin)}<small class="hide-usd">(MIN)</small></strong> — <strong class='f_Strong'>${Util.convertCNY(priceMax)}<small class="hide-usd">(MAX)</small></strong>`;
 
@@ -189,7 +190,7 @@ module Adjust_Listings {
     }
 
     /**
-     * Fetch price history for a given item in the last X days
+     * Fetch price history for a given item in the last X days. Uses the same API as the "Price Trend" tab
      * @param goodsId
      * @param days 7 or 30
      * @returns Array of [timestamp, price in rmb] pairs

--- a/sources/Adjust_Settings.ts
+++ b/sources/Adjust_Settings.ts
@@ -319,6 +319,7 @@ module Adjust_Settings {
                 ExtensionSettings.save(Settings.EXPERIMENTAL_ADJUST_POPULAR, isCheckboxSelected(Settings.EXPERIMENTAL_ADJUST_POPULAR));
                 ExtensionSettings.save(Settings.EXPERIMENTAL_FETCH_NOTIFICATION, isCheckboxSelected(Settings.EXPERIMENTAL_FETCH_NOTIFICATION));
                 ExtensionSettings.save(Settings.EXPERIMENTAL_FETCH_FAVOURITE_BARGAIN_STATUS, isCheckboxSelected(Settings.EXPERIMENTAL_FETCH_FAVOURITE_BARGAIN_STATUS));
+                ExtensionSettings.save(Settings.EXPERIMENTAL_FETCH_ITEM_PRICE_HISTORY, readSelectOption(Settings.EXPERIMENTAL_FETCH_ITEM_PRICE_HISTORY));
 
                 // write settings
                 ExtensionSettings.finalize();
@@ -596,6 +597,28 @@ module Adjust_Settings {
         makeCheckboxOption(Settings.EXPERIMENTAL_FETCH_FAVOURITE_BARGAIN_STATUS, {
             title: 'Fetch Favourite Bargain Status',
             description: '!!!BuffUtility!!!\n!!!Experimental!!!\n!!!Danger!!!\n!!!READ!!!\nThis will check the bargain status on favourites, to adjust the buttons accordingly, HOWEVER this is somewhat dangerous, as it will push API requests that are normally uncommon, use with caution. Setting will stay experimental until a better alternative is possibly discovered.'
+        }, ex_table);
+
+        // experimental fetch item price history
+        makeSelectOption(Settings.EXPERIMENTAL_FETCH_ITEM_PRICE_HISTORY, [
+            {
+                value: `${ExtensionSettings.PriceHistoryRange.OFF}`,
+                displayStr: 'Off',
+                selected: storedSettings[Settings.EXPERIMENTAL_FETCH_ITEM_PRICE_HISTORY] == ExtensionSettings.PriceHistoryRange.OFF
+            },
+            {
+                value: `${ExtensionSettings.PriceHistoryRange.WEEKLY}`,
+                displayStr: '7 Days',
+                selected: storedSettings[Settings.EXPERIMENTAL_FETCH_ITEM_PRICE_HISTORY] == ExtensionSettings.PriceHistoryRange.WEEKLY
+            },
+            {
+                value: `${ExtensionSettings.PriceHistoryRange.MONTHLY}`,
+                displayStr: '30 Days',
+                selected: storedSettings[Settings.EXPERIMENTAL_FETCH_ITEM_PRICE_HISTORY] == ExtensionSettings.PriceHistoryRange.MONTHLY
+            }
+        ], {
+            title: 'Fetch item price history',
+            description: '!!!BuffUtility!!!\n!!!Experimental!!!\n!!!Danger!!!\n!!!READ!!!\nThis will add a price history to the header of item pages, HOWEVER this is somewhat dangerous, as it will push API requests that are normally uncommon, use with caution. Setting will stay experimental until a better alternative is possibly discovered.'
         }, ex_table);
 
         // append experimental settings

--- a/sources/ExtensionSettings.ts
+++ b/sources/ExtensionSettings.ts
@@ -31,6 +31,12 @@ module ExtensionSettings {
         LEFT
     }
 
+    export const enum PriceHistoryRange {
+        OFF,
+        WEEKLY,
+        MONTHLY
+    }
+
     export const FILTER_SORT_BY = {
         'Default': 'default',
         'Newest': 'created.desc',
@@ -91,7 +97,9 @@ module ExtensionSettings {
         // 2.1.8 -> setting will be merged into show toast on action
         EXPERIMENTAL_FETCH_NOTIFICATION = 'experimental_fetch_notification',
         // [TBA] -> setting will be moved to advanced settings
-        EXPERIMENTAL_FETCH_FAVOURITE_BARGAIN_STATUS = 'fetch_favourite_bargain_status'
+        EXPERIMENTAL_FETCH_FAVOURITE_BARGAIN_STATUS = 'fetch_favourite_bargain_status',
+        // [TBA] -> setting will be moved to advanced settings
+        EXPERIMENTAL_FETCH_ITEM_PRICE_HISTORY = 'fetch_item_price_history'
     }
 
     export interface SettingsProperties {
@@ -124,6 +132,7 @@ module ExtensionSettings {
         [Settings.EXPERIMENTAL_ADJUST_POPULAR]: boolean;
         [Settings.EXPERIMENTAL_FETCH_NOTIFICATION]: boolean;
         [Settings.EXPERIMENTAL_FETCH_FAVOURITE_BARGAIN_STATUS]: boolean;
+        [Settings.EXPERIMENTAL_FETCH_ITEM_PRICE_HISTORY]: PriceHistoryRange;
     }
 
     const DEFAULT_SETTINGS: SettingsProperties = {
@@ -155,7 +164,8 @@ module ExtensionSettings {
         [Settings.EXPERIMENTAL_ALLOW_FAVOURITE_BARGAIN]: true,
         [Settings.EXPERIMENTAL_ADJUST_POPULAR]: true,
         [Settings.EXPERIMENTAL_FETCH_NOTIFICATION]: true,
-        [Settings.EXPERIMENTAL_FETCH_FAVOURITE_BARGAIN_STATUS]: false
+        [Settings.EXPERIMENTAL_FETCH_FAVOURITE_BARGAIN_STATUS]: false,
+        [Settings.EXPERIMENTAL_FETCH_ITEM_PRICE_HISTORY]: PriceHistoryRange.OFF
     };
 
     const VALIDATORS: {
@@ -189,7 +199,8 @@ module ExtensionSettings {
         [Settings.EXPERIMENTAL_ALLOW_FAVOURITE_BARGAIN]: (value) => validateBoolean(value, DEFAULT_SETTINGS[Settings.EXPERIMENTAL_ALLOW_FAVOURITE_BARGAIN]),
         [Settings.EXPERIMENTAL_ADJUST_POPULAR]: (value) => validateBoolean(value, DEFAULT_SETTINGS[Settings.EXPERIMENTAL_ADJUST_POPULAR]),
         [Settings.EXPERIMENTAL_FETCH_NOTIFICATION]: (value) => validateBoolean(value, DEFAULT_SETTINGS[Settings.EXPERIMENTAL_FETCH_NOTIFICATION]),
-        [Settings.EXPERIMENTAL_FETCH_FAVOURITE_BARGAIN_STATUS]: (value) => validateBoolean(value, DEFAULT_SETTINGS[Settings.EXPERIMENTAL_FETCH_FAVOURITE_BARGAIN_STATUS])
+        [Settings.EXPERIMENTAL_FETCH_FAVOURITE_BARGAIN_STATUS]: (value) => validateBoolean(value, DEFAULT_SETTINGS[Settings.EXPERIMENTAL_FETCH_FAVOURITE_BARGAIN_STATUS]),
+        [Settings.EXPERIMENTAL_FETCH_ITEM_PRICE_HISTORY]: (value) => validateNumber(value, DEFAULT_SETTINGS[Settings.EXPERIMENTAL_FETCH_ITEM_PRICE_HISTORY])
     };
 
     let settings: SettingsProperties = {


### PR DESCRIPTION
For evaluating the price of a specific item, Buff offers past trade records and a price trend graph.
As it is kinda tedious scrolling through those pages, this feature displays the highest and lowest sale price in the item page header. 

It is possible to choose between a 7 or 30 days range and prices are converted into your selected currency automatically. The 90 days range redeemable with the observer benefit is not yet implemented as this would require authorization in the API call.

The feature settings:
![Screenshot_246](https://user-images.githubusercontent.com/21990230/190871449-f4ccb61b-fc8f-4eec-973e-c205cc26fd89.png)

The item page with 7 days range:
![Screenshot_247](https://user-images.githubusercontent.com/21990230/190871462-5f331674-ef9f-460a-b1b5-595dcb7a7a91.png)

As also mentioned in the setting tooltip, this feature makes an API request equal to a click on the "Price Trend"-tab. Use with caution until further notice.