### PR TITLE
Added color scheme to popups

### DIFF
--- a/sources/Start.ts
+++ b/sources/Start.ts
@@ -209,6 +209,41 @@ if (storedSettings[Settings.USE_SCHEME]) {
 .dark-theme .l_Layout .cont_main .user-record .delete-bookmark {
     color: ${storedSettings[Settings.COLOR_SCHEME][2]} !important;
 }
+.dark-theme .l_Layout .cont_main .user-record .i_Btn_hollow {
+    background-color: #959595;
+    color: #fff;
+}
+
+/* bargain popup */
+.dark-theme .popup_supply .popup-header,
+.dark-theme .popup_supply .popup-cont,
+.dark-theme .popup_supply .popup-cont .popup-good-summary,
+.dark-theme .popup_supply .popup-cont .popup-good-summary .input-cont .j_filter {
+    background: ${storedSettings[Settings.COLOR_SCHEME][0]};
+}
+.dark-theme .popup_supply .input-cont .c_Gray {
+    color: ${storedSettings[Settings.COLOR_SCHEME][2]} !important;
+}
+
+/* selling popup */
+.dark-theme .popup_charge .popup-header,
+.dark-theme .popup_charge .popup-cont {
+    background: ${storedSettings[Settings.COLOR_SCHEME][0]};
+}
+.dark-theme .popup_charge .popup-cont .list_tb_csgo tr:hover {
+    background: ${storedSettings[Settings.COLOR_SCHEME][1]};
+}
+
+/* selling description popup */
+.dark-theme .popup_guide_sell .popup-header,
+.dark-theme .popup_guide_sell .popup-cont {
+    background: ${storedSettings[Settings.COLOR_SCHEME][0]};
+}
+.dark-theme .popup_guide_sell textarea {
+    background: ${storedSettings[Settings.COLOR_SCHEME][0]};
+    color: ${storedSettings[Settings.COLOR_SCHEME][2]} !important;
+}
+
 `);
 
     let body = document.querySelector('body');

--- a/sources/Start.ts
+++ b/sources/Start.ts
@@ -244,6 +244,16 @@ if (storedSettings[Settings.USE_SCHEME]) {
     color: ${storedSettings[Settings.COLOR_SCHEME][2]} !important;
 }
 
+/* applied sticker popup */
+.dark-theme .popup_flower .popup-header,
+.dark-theme .popup_flower .popup-cont,
+.dark-theme .popup_flower .popup-cont li {
+    background: ${storedSettings[Settings.COLOR_SCHEME][0]} !important;
+}
+.dark-theme .popup_flower .popup-cont tr:hover {
+    background: ${storedSettings[Settings.COLOR_SCHEME][1]} !important;
+}
+
 `);
 
     let body = document.querySelector('body');


### PR DESCRIPTION
This is a change for everyone using the custom color scheme by BuffUtility.

Previously unsupported popups will now also use the custom color scheme. This includes bargaining, selling as well as description popups.

E.g. the bargaining popup:
![Screenshot_252](https://user-images.githubusercontent.com/21990230/191148585-95b34a8b-2bfa-42ac-9003-6df13eb7c512.png)

Now it looks like this:
![Screenshot_251](https://user-images.githubusercontent.com/21990230/191148638-00e62494-c809-403a-8f98-d900d53d3813.png)
![Screenshot_249](https://user-images.githubusercontent.com/21990230/191148656-2f92dd5a-8d16-47e8-b983-0cc7e8239203.png)
![Screenshot_250](https://user-images.githubusercontent.com/21990230/191148660-da33336a-3dc2-49b2-91a3-0ac515529eba.png)

