### PR TITLE
Fixed color scheme bugs in listing and shop pages

### DIFF
--- a/resources/css/Theme.css
+++ b/resources/css/Theme.css
@@ -41,7 +41,8 @@ html {
 
 .dark-theme .des_row,
 .dark-theme .pager li.disabled span,
-.dark-theme .list_tb th {
+.dark-theme .list_tb th,
+.dark-theme .list_tb #rank-title {
     background: var(--bu-color-0, #121212) !important;
     border-color: var(--bu-color-2, #bfbfbf) !important;
 }
@@ -65,12 +66,20 @@ html {
     border-color: var(--bu-color-2, #bfbfbf);
 }
 
+.dark-theme .pinterest .pinterest-item,
+.dark-theme .pinterest .pinterest-item .pinterest-user {
+    color: var(--bu-color-2, #bfbfbf);
+    border-color: var(--bu-color-2, #bfbfbf);
+    background: var(--bu-color-0, #121212) !important;
+}
+
 /* shop pages */
 .dark-theme .l_Layout .market-card,
 .dark-theme .shop .list_card,
 .dark-theme .shop .shop-recommend-cont,
 .dark-theme .shop .shop-recommend-cont .slider-handle,
-.dark-theme .shop .shop-recommend-list li {
+.dark-theme .shop .shop-recommend-list li,
+.dark-theme .shop .card-pager {
     background: var(--bu-color-0, #121212) !important;
 }
 


### PR DESCRIPTION
This change aims to fix the below listed bugs with the custom color scheme.

From the "Float Ranking" page on an item's listing page (goods/id#tab=selling):
![Screenshot_314](https://user-images.githubusercontent.com/21990230/208256897-18763a4a-48b3-492e-8860-1c2c2fca4474.png)
From the "Gallery" page on an item's listing page (goods/id#tab=user-preview):
![Screenshot_315](https://user-images.githubusercontent.com/21990230/208256899-802945c4-22ac-4b13-a992-5741591d6bf2.png)
From a user's Buff shop page (shop/uid):
![Screenshot_316](https://user-images.githubusercontent.com/21990230/208256900-ecacabb8-7e6c-486b-aff9-e619c9dae7c1.png)
