### PR TITLE
Bugfix: Support for the price drop benefit

### DIFF
--- a/sources/adjustments/Adjust_Favourites.ts
+++ b/sources/adjustments/Adjust_Favourites.ts
@@ -28,7 +28,7 @@ module Adjust_Favourites {
 
             // convert price
             let contentTDList = <NodeListOf<HTMLElement>>row.querySelectorAll('td');
-            let priceTD = null;
+            let priceTD: HTMLElement | null = null;
             for (let i = 0, l = contentTDList.length; i < l; i ++) {
                 if (contentTDList.item(i).innerText.indexOf(GlobalConstants.SYMBOL_YUAN) > -1) {
                     priceTD = contentTDList.item(i);
@@ -36,22 +36,15 @@ module Adjust_Favourites {
                 }
             }
 
-            if (priceTD) {
+            if (priceTD && priceTD.children.length >= 2) {
                 let priceCNY = +((/¥ (\d+(\.\d+)?)/.exec(priceTD.innerText) ?? [null, NaN])[1]);
                 if (isFinite(priceCNY)) {
                     let priceStr = `${GlobalConstants.SYMBOL_YUAN} ${await Util.formatNumber(priceCNY)}`;
 
                     const { convertedSymbol, convertedFormattedValue } = await Util.convertCNYRaw(priceCNY);
 
-                    priceTD.innerHTML = Util.buildHTML('p', {
-                        content: [Util.buildHTML('strong', {
-                            class: 'f_Strong',
-                            content: [ priceStr ]
-                        })]
-                    }) + Util.buildHTML('p', {
-                        class: 'c_Gray f_12px',
-                        content: [ `(${convertedSymbol} ${convertedFormattedValue})` ]
-                    });
+                    priceTD.children[0].children[0].innerHTML = priceStr;
+                    priceTD.children[1].innerHTML = `(${convertedSymbol} ${convertedFormattedValue})`;
                 }
             }
 


### PR DESCRIPTION
This change aims to support the price drop benefit, purchasable via Buff points, in the Favorites page.

As I recently bought the "price drop alert" benefit with Buff points, I noticed that BuffUtility does not support this benefit in the Favorites page. The "dropped/raised by"-text as well as the arrows were not displayed due to how BuffUtility manages the price conversion.

Now everything will be displayed correctly again, as you can see in this example:
![Screenshot_332](https://user-images.githubusercontent.com/21990230/209475776-99c45103-cd63-403d-b8df-8c47c87749a3.png)

