### PR TITLE
Feature: team descriptions for souvenir packages

### DIFF
--- a/options/options.ts
+++ b/options/options.ts
@@ -583,6 +583,12 @@ module Options {
             description: '<u><b>BuffUtility<br>Experimental<br></b></u>Adjust the "Trade Records" tab for an items page, showing things such as currency conversion, and difference to reference price.'
         });
 
+        // Settings.EXPERIMENTAL_SHOW_SOUVENIR_TEAMS
+        experimentalSettings += await createCheckboxOption(Settings.EXPERIMENTAL_SHOW_SOUVENIR_TEAMS, {
+            title: 'Show Souvenir Teams',
+            description: '<u><b>BuffUtility<br>Experimental<br></b></u>Utilize the attributes field in market listings and favorites to display the teams of a souvenir package.'
+        });
+
         // --- PSE Settings ---
 
         // Settings.PSE_ADVANCED_PAGE_NAVIGATION

--- a/sources/@typings/BuffTypes.d.ts
+++ b/sources/@typings/BuffTypes.d.ts
@@ -148,7 +148,7 @@ declare module BuffTypes {
             paintindex: number;
             paintseed: number;
             stickers: Sticker[];
-            tournament_tags: any[];
+            tournament_tags: CommonType.TournamentTag[];
         }
 
         export interface AssetInfo {

--- a/sources/ExtensionSettings.ts
+++ b/sources/ExtensionSettings.ts
@@ -156,6 +156,7 @@ module ExtensionSettings {
         EXPERIMENTAL_SHOW_LISTING_DATE = 'show_listing_date',
         // 2.2.0 -> setting will become default
         EXPERIMENTAL_ADJUST_TRADE_RECORDS = 'adjust_trade_records',
+        EXPERIMENTAL_SHOW_SOUVENIR_TEAMS = 'show_souvenir_teams',
 
         ALLOW_EXTENSION_REQUESTS = 'allow_extension_requests',
 
@@ -228,6 +229,7 @@ module ExtensionSettings {
         [Settings.EXPERIMENTAL_AUTOMATIC_BARGAIN_DEFAULT]: number;
         [Settings.EXPERIMENTAL_SHOW_LISTING_DATE]: boolean;
         [Settings.EXPERIMENTAL_ADJUST_TRADE_RECORDS]: boolean;
+        [Settings.EXPERIMENTAL_SHOW_SOUVENIR_TEAMS]: boolean;
 
         // Misc
 
@@ -549,6 +551,12 @@ module ExtensionSettings {
         [Settings.EXPERIMENTAL_ADJUST_TRADE_RECORDS]: {
             default: true,
             export: '2x14',
+            transform: InternalStructureTransform.BOOLEAN,
+            validator: validateBoolean
+        },
+        [Settings.EXPERIMENTAL_SHOW_SOUVENIR_TEAMS]: {
+            default: false,
+            export: '2x15',
             transform: InternalStructureTransform.BOOLEAN,
             validator: validateBoolean
         },

--- a/sources/adjustments/Adjust_Favourites.ts
+++ b/sources/adjustments/Adjust_Favourites.ts
@@ -61,6 +61,7 @@ module Adjust_Favourites {
             }
 
             let assetInfo: BuffTypes.SellOrder.AssetInfo = JSON.parse(aAssetInfo.getAttribute('data-asset-info'));
+            let goodsName = aAssetInfo.getAttribute('data-goods-name');
 
             async function _csgoSpecific(): Promise<void> {
                 let itemType = nameContainer.innerText.split(' | ')[0].replace('（★）', '');
@@ -104,6 +105,15 @@ module Adjust_Favourites {
                     Util.addAnchorClipboardAction(aCopyGen, gen);
 
                     wearContainer.appendChild(aCopyGen);
+                } else if (goodsName.endsWith('Souvenir Package')) {
+                    let teams = assetInfo.info.tournament_tags.map(x => String(x.localized_name)).slice(0, 2);
+                    // sticker div is empty when item has no stickers
+                    let stickerContainer = <HTMLElement>row.querySelector('.csgo_sticker');
+                    let teamsDiv = document.createElement('div');
+                    teamsDiv.setAttribute('style', 'display: flex; flex-direction: column; align-items: center; color: #ffd700; opacity: 0.8;');
+                    teamsDiv.setAttribute('class', 'f_12px');
+                    teamsDiv.innerHTML = `<span>${teams[0]}</span><div class="clear"></div><span>vs</span><div class="clear"></div><span>${teams[1]}</span>`;
+                    stickerContainer.appendChild(teamsDiv);
                 }
             }
 
@@ -125,6 +135,8 @@ module Adjust_Favourites {
 
             let price = +aBuy.getAttribute('data-price');
             let lowest_bargain_price = price * 0.8;
+
+
 
             if (await getSetting(Settings.EXPERIMENTAL_ALLOW_FAVOURITE_BARGAIN)) {
                 // Note: this feature is yet unable to check if the seller has disabled bargaining

--- a/sources/adjustments/Adjust_Favourites.ts
+++ b/sources/adjustments/Adjust_Favourites.ts
@@ -105,14 +105,15 @@ module Adjust_Favourites {
                     Util.addAnchorClipboardAction(aCopyGen, gen);
 
                     wearContainer.appendChild(aCopyGen);
-                } else if (goodsName.endsWith('Souvenir Package')) {
+                } else if (goodsName.endsWith('Souvenir Package') && await getSetting(Settings.EXPERIMENTAL_SHOW_SOUVENIR_TEAMS)) {
                     let teams = assetInfo.info.tournament_tags.map(x => String(x.localized_name)).slice(0, 2);
                     // sticker div is empty when item has no stickers
                     let stickerContainer = <HTMLElement>row.querySelector('.csgo_sticker');
                     let teamsDiv = document.createElement('div');
-                    teamsDiv.setAttribute('style', 'display: flex; flex-direction: column; align-items: center; color: #ffd700; opacity: 0.8;');
                     teamsDiv.setAttribute('class', 'f_12px');
+                    teamsDiv.setAttribute('style', 'display: flex; flex-direction: column; align-items: center; color: #ffd700; opacity: 0.8;');
                     teamsDiv.innerHTML = `<span>${teams[0]}</span><div class="clear"></div><span>vs</span><div class="clear"></div><span>${teams[1]}</span>`;
+                    stickerContainer.setAttribute('style', 'float: none;');
                     stickerContainer.appendChild(teamsDiv);
                 }
             }

--- a/sources/adjustments/Adjust_Listings.ts
+++ b/sources/adjustments/Adjust_Listings.ts
@@ -329,14 +329,15 @@ module Adjust_Listings {
 
                         Util.signal(['updateHashData'], null, paramData);
                     });
-                } else if (goodsInfo.market_hash_name.endsWith('Souvenir Package')) {
+                } else if (goodsInfo.market_hash_name.endsWith('Souvenir Package') && await getSetting(Settings.EXPERIMENTAL_SHOW_SOUVENIR_TEAMS)) {
                     let teams = dataRow.asset_info.info.tournament_tags.map(x => String(x.localized_name)).slice(0, 2);
                     // sticker div is empty when item has no stickers
                     let stickerContainer = <HTMLElement>row.querySelector('.csgo_sticker');
                     let teamsDiv = document.createElement('div');
-                    teamsDiv.setAttribute('style', 'display: flex; flex-direction: column; align-items: center; color: #ffd700; opacity: 0.8; margin-left: 20px;');
                     teamsDiv.setAttribute('class', 'f_12px');
+                    teamsDiv.setAttribute('style', 'display: flex; flex-direction: column; align-items: center; color: #ffd700; opacity: 0.8;');
                     teamsDiv.innerHTML = `<span>${teams[0]}</span><div class="clear"></div><span>vs</span><div class="clear"></div><span>${teams[1]}</span>`;
+                    stickerContainer.setAttribute('style', 'float: none;');
                     stickerContainer.appendChild(teamsDiv);
                 }
 

--- a/sources/adjustments/Adjust_Listings.ts
+++ b/sources/adjustments/Adjust_Listings.ts
@@ -322,6 +322,15 @@ module Adjust_Listings {
 
                         Util.signal(['updateHashData'], null, paramData);
                     });
+                } else if (goodsInfo.market_hash_name.endsWith('Souvenir Package')) {
+                    let teams = dataRow.asset_info.info.tournament_tags.map(x => String(x.localized_name)).slice(0, 2);
+                    // sticker div is empty when item has no stickers
+                    let stickerContainer = <HTMLElement>row.querySelector('.csgo_sticker');
+                    let teamsDiv = document.createElement('div');
+                    teamsDiv.setAttribute('style', 'display: flex; flex-direction: column; align-items: center; color: #ffd700; opacity: 0.8; margin-left: 20px;');
+                    teamsDiv.setAttribute('class', 'f_12px');
+                    teamsDiv.innerHTML = `<span>${teams[0]}</span><div class="clear"></div><span>vs</span><div class="clear"></div><span>${teams[1]}</span>`;
+                    stickerContainer.appendChild(teamsDiv);
                 }
 
                 const aShare = document.createElement('a');


### PR DESCRIPTION
Since 2021, souvenir packages stopped featuring MVPs. Nevertheless the applied team stickers still play a fundamental role in pricing those packages. Buff unfortunately makes it very difficult differentiating packages by only mentioning the teams in the item popup:
![Item Popup](https://user-images.githubusercontent.com/21990230/220636387-215d10e4-1241-4bee-8d5f-39384d88d155.png)

With this feature, teams are now mentioned directly in the market listings and on the favorites page (if a package listing has been favorited):
![Feature in market listings](https://user-images.githubusercontent.com/21990230/220644235-e9095055-856a-497f-b770-b31c29fa60e7.png)
![Feature in favorites](https://user-images.githubusercontent.com/21990230/220644390-5b147154-adba-43ac-81d2-6c1be761f49a.png)

The color is inherited from the item popup description with an additional applied opacity (80%) to reduce the contrasting effect. Font size is further inherited by the MVP text used in older souvenir listings, e.g.:
![Feature for older souvenir listings](https://user-images.githubusercontent.com/21990230/220645489-90e2594d-7d73-498c-805c-6036d54e971b.png)