### PR TITLE
Sharing in shops / market supports new link format

### DIFF
--- a/sources/Util.ts
+++ b/sources/Util.ts
@@ -391,10 +391,10 @@ module Util {
 
     // <a> action injection
 
-    export function addAnchorShareAction(classid: string, instanceid: string, assetid: string, sellOrderId: string): HTMLElement {
+    export function addAnchorShareAction(goods_id: number, classid: string, instanceid: string, assetid: string, sellOrderId: string): HTMLElement {
         const aShare = document.createElement('a');
         aShare.setAttribute('style', 'cursor: pointer;');
-        aShare.setAttribute('href', `https://buff.163.com/market/m/item_detail?classid=${classid}&instanceid=${instanceid}&game=csgo&assetid=${assetid}&sell_order_id=${sellOrderId}`);
+        aShare.setAttribute('href', `https://buff.163.com/goods/${goods_id}?appid=730&classid=${classid}&instanceid=${instanceid}&game=csgo&assetid=${assetid}&sell_order_id=${sellOrderId}`);
         aShare.setAttribute('target', '_blank');
         aShare.innerHTML = '<i class="icon icon_link j_tips_handler" data-direction="bottom" data-title="Share"></i>';
 

--- a/sources/adjustments/Adjust_Market.ts
+++ b/sources/adjustments/Adjust_Market.ts
@@ -261,7 +261,7 @@ module Adjust_Market {
                 priceBox.append(span);
             }
 
-            tagBox.insertBefore(Util.addAnchorShareAction(dataRow.asset_info.classid, dataRow.asset_info.instanceid, dataRow.asset_info.assetid, dataRow.id), tagBox.firstChild);
+            tagBox.insertBefore(Util.addAnchorShareAction(dataRow.goods_id, dataRow.asset_info.classid, dataRow.asset_info.instanceid, dataRow.asset_info.assetid, dataRow.id), tagBox.firstChild);
 
             const schemaData = (await ISchemaHelper.find(goodsInfo.market_hash_name, true, goodsInfo?.tags?.exterior?.internal_name == 'wearcategoryna')).data[0];
 

--- a/sources/adjustments/Adjust_Shop.ts
+++ b/sources/adjustments/Adjust_Shop.ts
@@ -63,7 +63,7 @@ module Adjust_Shop {
                 const schemaData = (await ISchemaHelper.find(goodsInfo.market_hash_name, true, goodsInfo?.tags?.exterior?.internal_name == 'wearcategoryna')).data[0];
 
                 if (tagBox.children.length == 2) {
-                    tagBox.insertBefore(Util.addAnchorShareAction(dataRow.asset_info.classid, dataRow.asset_info.instanceid, dataRow.asset_info.assetid, dataRow.id), tagBox.firstChild);
+                    tagBox.insertBefore(Util.addAnchorShareAction(dataRow.goods_id, dataRow.asset_info.classid, dataRow.asset_info.instanceid, dataRow.asset_info.assetid, dataRow.id), tagBox.firstChild);
                     // only append if we have schema data, which we always should have, but some items have weird CH mappings
                     if (schemaData) {
                         let aCopyGen = document.createElement('a');


### PR DESCRIPTION
The share links in the market "popular" tab (top_bookmarked) and in shops are now using the new link format.