### PR TITLE
Theming for new weaponbox popup

### DIFF
--- a/resources/css/Theme.css
+++ b/resources/css/Theme.css
@@ -166,6 +166,29 @@ html {
     background: var(--bu-color-1, #1f1f1f) !important;
 }
 
+/* weapon case popup */
+.dark-theme .popup_weaponbox,
+.dark-theme .popup_weaponbox .weapon-col1,
+.dark-theme .popup_weaponbox .weapon-col2 {
+    background: var(--bu-color-0, #121212);
+}
+
+
+.dark-theme .popup_weaponbox .weapon-col2 li {
+    background: var(--bu-color-0, #121212) !important;
+}
+
+.dark-theme .popup_weaponbox .weapon-col1 li.on,
+.dark-theme .popup_weaponbox li:hover {
+    background: var(--bu-color-1, #1f1f1f) !important;
+}
+
+.dark-theme .popup_weaponbox h2,
+.dark-theme .popup_weaponbox a,
+.dark-theme .popup_weaponbox .weapon-cate {
+    color: var(--bu-color-2, #bfbfbf) !important;
+}
+
 /* payment methods popup */
 .dark-theme .popup .popup-header,
 .dark-theme .popup .popup-tip,

--- a/resources/css/Theme.css
+++ b/resources/css/Theme.css
@@ -173,6 +173,11 @@ html {
     background: var(--bu-color-0, #121212);
 }
 
+.dark-theme .popup_weaponbox h2,
+.dark-theme .popup_weaponbox a,
+.dark-theme .popup_weaponbox .weapon-cate {
+    color: var(--bu-color-2, #bfbfbf) !important;
+}
 
 .dark-theme .popup_weaponbox .weapon-col2 li {
     background: var(--bu-color-0, #121212) !important;
@@ -181,12 +186,6 @@ html {
 .dark-theme .popup_weaponbox .weapon-col1 li.on,
 .dark-theme .popup_weaponbox li:hover {
     background: var(--bu-color-1, #1f1f1f) !important;
-}
-
-.dark-theme .popup_weaponbox h2,
-.dark-theme .popup_weaponbox a,
-.dark-theme .popup_weaponbox .weapon-cate {
-    color: var(--bu-color-2, #bfbfbf) !important;
 }
 
 /* payment methods popup */


### PR DESCRIPTION
This change aims to bring the standard BuffUtility theming to the new popup "popup_weaponbox" available for all items on Buff.

The popup is accessible via 2 icons in the item header:
![Screenshot_431](https://user-images.githubusercontent.com/21990230/229861769-05f6dbbb-0ca2-44bd-b3b9-8a8b13becc9d.png)
The theming also supports hover and active stages similar to the general listings page:
![Screenshot_432](https://user-images.githubusercontent.com/21990230/229862819-548ee51a-dd31-4009-b920-88232eeddd68.png)
